### PR TITLE
Spring Data REST @Disabled 처리

### DIFF
--- a/src/test/java/com/nightdiver/javaboard/controller/DataRestTest.java
+++ b/src/test/java/com/nightdiver/javaboard/controller/DataRestTest.java
@@ -1,10 +1,10 @@
 package com.nightdiver.javaboard.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 // @WebMvcTest // MockMvc 사용 가능. controller 관련 bean만 등록
+@Disabled("Spring Data REST 는 공부목적 제외하곤 테스트 필요없어서 Disable 처리함")
 @DisplayName("DataRest 테스트")
 @Transactional
 @AutoConfigureMockMvc // MockMvc 사용 가능


### PR DESCRIPTION
기존 Spring Data REST 테스트 코드의 단점과 낮은 필요성을 판단으로 @Disabled 처리하였습니다.
<br>

**기존 테스트 코드의 단점**
- 통합 테스트로 구성되어 무겁다
- 실제 DB를 건들여 부담스럽다
<br>

**낮은 필요성**

Spring Data REST에서 제공되는 기능이기에 별도의 테스트 코드 없이 신뢰하고 사용하여도 상관없다.