### PR TITLE
gitignore 에 .jpd (JPA Buddy 설정파일) 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,4 +226,7 @@ src/main/resources/secrets.yml
 ### Ignore QClasses in QueryDSL
 src/main/generated
 
+### JPA Buddy
+.jpb
+
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,intellij+all,windows,macos,visualstudiocode


### PR DESCRIPTION
JPA Buddy 설정파일은 프로젝트에 큰 연관이 있다기보단 개개인의 개발환경에 의미가 있다보니 gitignore 에서 추적되지 않도록 추가하였다.

This closes #22 