### PR TITLE
Article 페이지네이션 기능 추가

### DIFF
--- a/src/main/java/com/nightdiver/javaboard/controller/ArticleController.java
+++ b/src/main/java/com/nightdiver/javaboard/controller/ArticleController.java
@@ -6,8 +6,11 @@ import com.nightdiver.javaboard.domain.type.SearchType;
 import com.nightdiver.javaboard.dto.response.ArticleResponse;
 import com.nightdiver.javaboard.dto.response.ArticleWithCommentsResponse;
 import com.nightdiver.javaboard.service.ArticleService;
+import com.nightdiver.javaboard.service.PaginationService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
@@ -22,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Controller
 public class ArticleController {
     private final ArticleService articleService;
+    private final PaginationService paginationService;
 
     @GetMapping
     public String articles(
@@ -30,7 +34,10 @@ public class ArticleController {
             @PageableDefault(size = 10, sort = "createdAt", direction = DESC) Pageable pageable,
             ModelMap modelMap
     ) {
-        modelMap.addAttribute("articles", articleService.searchArticles(searchType, searchKeyword, pageable).map(ArticleResponse::from));
+        Page<ArticleResponse> articles = articleService.searchArticles(searchType, searchKeyword, pageable).map(ArticleResponse::from);
+        List<Integer> paginationBarNumbers = paginationService.getPaginationBarNumbers(articles.getTotalPages(), pageable.getPageNumber());
+        modelMap.addAttribute("articles", articles);
+        modelMap.addAttribute("paginationBarNumbers", paginationBarNumbers);
 
         return "articles/index";
     }

--- a/src/main/java/com/nightdiver/javaboard/service/PaginationService.java
+++ b/src/main/java/com/nightdiver/javaboard/service/PaginationService.java
@@ -1,0 +1,25 @@
+package com.nightdiver.javaboard.service;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+public class PaginationService {
+    private static final int BAR_LENGTH = 5;
+
+    public List<Integer> getPaginationBarNumbers(int totalPages, int currentPageNumber) {
+        int startNumber = Math.max(0, currentPageNumber - (BAR_LENGTH / 2));
+        int endNumber = Math.min(totalPages, startNumber + BAR_LENGTH);
+
+        return IntStream.range(startNumber, endNumber)
+                .boxed()
+                .toList();
+    }
+
+    public int currentBarLength() {
+        return BAR_LENGTH;
+    }
+}

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -95,9 +95,18 @@
         <div class="row">
             <nav id="pagination" aria-label="Page navigation">
                 <ul class="pagination justify-content-center">
-                    <li class="page-item"><a class="page-link" href="#">Previous</a></li>
-                    <li class="page-item"><a class="page-link" href="#">1</a></li>
-                    <li class="page-item"><a class="page-link" href="#">Next</a></li>
+                    <li class="page-item"><a class="page-link" href="#"
+                                             th:text="previous"
+                                             th:href="@{/articles(page=${articles.number - 1}, searchType=${param.searchType}, searchKeyword=${param.searchKeyword})}"
+                                             th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')">Previous</a></li>
+                    <li class="page-item" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}"><a class="page-link" href="#"
+                                             th:text="${pageNumber + 1}"
+                                             th:href="@{/articles(page=${pageNumber}, searchType=${param.searchType}, searchKeyword=${param.searchKeyword})}"
+                                             th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')">1</a></li>
+                    <li class="page-item"><a class="page-link" href="#"
+                                             th:text="next"
+                                             th:href="@{/articles(page=${articles.number + 1}, searchType=${param.searchType}, searchKeyword=${param.searchKeyword})}"
+                                             th:class="'page-link' + (${articles.number} >= ${articles.totalPages} ? ' disabled' : '')">Next</a></li>
                 </ul>
             </nav>
         </div>

--- a/src/test/java/com/nightdiver/javaboard/service/PaginationServiceTest.java
+++ b/src/test/java/com/nightdiver/javaboard/service/PaginationServiceTest.java
@@ -1,0 +1,64 @@
+package com.nightdiver.javaboard.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@DisplayName("비즈니스 로직 - 페이지네이션")
+@SpringBootTest(webEnvironment = NONE, classes = {PaginationService.class})
+class PaginationServiceTest {
+    private final PaginationService sut;
+
+    public PaginationServiceTest(@Autowired PaginationService paginationService) {
+        this.sut = paginationService;
+    }
+
+    @DisplayName("현재 페이지 번호와 총 페이지 수를 주면, 페이징 바 리스트를 만들어준다.")
+    @MethodSource
+    @ParameterizedTest(name = "[{index}] {0}, {1} -> {2}")
+    void givenCurrentPageNumberAndTotalPages_whenRequesting_thenReturnsPaginationBarNumbers(int totalPages, int currentPageNumber, List<Integer> expectedPaginationBarNumbers) {
+        // Given
+
+        // When
+        List<Integer> actualPaginationBarNumbers = sut.getPaginationBarNumbers(totalPages, currentPageNumber);
+
+        // Then
+        assertThat(actualPaginationBarNumbers).isEqualTo(expectedPaginationBarNumbers);
+    }
+
+    static Stream<Arguments> givenCurrentPageNumberAndTotalPages_whenRequesting_thenReturnsPaginationBarNumbers() {
+        return Stream.of(
+                Arguments.of(13, 0, List.of(0, 1, 2, 3, 4)),
+                Arguments.of(13, 1, List.of(0, 1, 2, 3, 4)),
+                Arguments.of(13, 2, List.of(0, 1, 2, 3, 4)),
+                Arguments.of(13, 3, List.of(1, 2, 3, 4, 5)),
+                Arguments.of(13, 4, List.of(2, 3, 4, 5, 6)),
+                Arguments.of(13, 5, List.of(3, 4, 5, 6, 7)),
+                Arguments.of(13, 6, List.of(4, 5, 6, 7, 8)),
+                Arguments.of(13, 10, List.of(8, 9, 10, 11, 12)),
+                Arguments.of(13, 11, List.of(9, 10, 11, 12)),
+                Arguments.of(13, 12, List.of(10, 11, 12))
+        );
+    }
+
+    @DisplayName("현재 설정되어 있는 페이지네이션 바의 길이를 알려준다.")
+    @Test
+    void givenNothing_whenCalling_thenReturnsCurrentBarLength() {
+        // Given
+
+        // When
+        int actualCurrentBarLength = sut.currentBarLength();
+
+        // Then
+        assertThat(actualCurrentBarLength).isEqualTo(5);
+    }
+}


### PR DESCRIPTION
뷰에서 페이징된 게시글 목록을 볼 수 있도록 타임리프와 `org.springframework.data.domain.Pageable` 관련 기능을 이용해 구현하였다.

`PaginationService` 를 통해서 페이지 단위 이동을 할 수 있는 숫자 Bar 를 얻을 수 있다.

articles/detail.html 에서 이전, 이후 글을 어떻게 가져올 지는 아직 고려 중이다. 정렬 기능이 추가된다면 조금 더 구현이 복잡해 질 수도 있기 때문이다.
